### PR TITLE
setuptools_scm: support reading version from archive

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,3 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst


### PR DESCRIPTION
**Description**
Currently, it's not possible to `pip install` the `labgrid` package by using the GitHub archive URL. However, `setuptools_scm` [supports](https://setuptools-scm.readthedocs.io/en/latest/usage/#git-archives) this with a few files added to the repo.

**Testing**
This fails:
```
pip install https://github.com/labgrid-project/labgrid/zipball/master
```
This succeeds:
```
pip install https://github.com/arm-software/labgrid/zipball/pip-install-from-archive
```

**Checklist**
- [ ] Documentation for the feature: N/A
- [ ] Tests for the feature: N/A
- [x] PR has been tested