### PR TITLE
remote: tag value validation in labgrid-client

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1427,7 +1427,7 @@ class ClientSession:
                 raise UserError(f"'{pair}' is not a valid filter (must contain a '=')")
             if not TAG_KEY.match(k):
                 raise UserError(f"Key '{k}' in filter '{pair}' is invalid")
-            if not TAG_KEY.match(v):
+            if not TAG_VAL.match(v):
                 raise UserError(f"Value '{v}' in filter '{pair}' is invalid")
             fltr[k] = v
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -15,7 +15,7 @@ def place(coordinator):
         spawn.close()
         assert spawn.exitstatus == 0, spawn.before.strip()
 
-    with pexpect.spawn('python -m labgrid.remote.client -p test set-tags board=bar') as spawn:
+    with pexpect.spawn('python -m labgrid.remote.client -p test set-tags board=8bar') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
         assert spawn.exitstatus == 0, spawn.before.strip()
@@ -271,7 +271,7 @@ def test_remoteplace_target(place_acquire, tmpdir):
     t.await_resources(t.resources)
 
     remote_place = t.get_resource("RemotePlace")
-    assert remote_place.tags == {"board": "bar"}
+    assert remote_place.tags == {"board": "8bar"}
 
 def test_remoteplace_target_without_env(request, place_acquire):
     from labgrid import Target
@@ -279,7 +279,7 @@ def test_remoteplace_target_without_env(request, place_acquire):
 
     t = Target(request.node.name)
     remote_place = RemotePlace(t, name="test")
-    assert remote_place.tags == {"board": "bar"}
+    assert remote_place.tags == {"board": "8bar"}
 
 def test_resource_conflict(place_acquire, tmpdir):
     with pexpect.spawn('python -m labgrid.remote.client -p test2 create') as spawn:
@@ -303,7 +303,7 @@ def test_resource_conflict(place_acquire, tmpdir):
         assert spawn.exitstatus == 0, spawn.before.strip()
 
 def test_reservation(place_acquire, tmpdir):
-    with pexpect.spawn('python -m labgrid.remote.client reserve --shell board=bar name=test') as spawn:
+    with pexpect.spawn('python -m labgrid.remote.client reserve --shell board=8bar name=test') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
         assert spawn.exitstatus == 0, spawn.before.strip()
@@ -510,7 +510,7 @@ def test_reservation_custom_config(place, exporter, tmpdir):
             name: test
     """
     )
-    with pexpect.spawn(f'python -m labgrid.remote.client -c {p} reserve --wait --shell board=bar name=test') as spawn:
+    with pexpect.spawn(f'python -m labgrid.remote.client -c {p} reserve --wait --shell board=8bar name=test') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
         assert spawn.exitstatus == 0, spawn.before.strip()


### PR DESCRIPTION
**Description**
This pull request is fixing the tag validation bug - for example:
labgrid-client -p my_place create
labgrid-client -p my_place set-tags my_tag=15
labgrid-client reserve my_tag=15 #error


<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [x] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->

Fixes #1570